### PR TITLE
Added a couple of new features

### DIFF
--- a/jquery.kinetic.js
+++ b/jquery.kinetic.js
@@ -30,7 +30,7 @@
                 right: 'kinetic-decelerating-right'
             },
 			initialOffset: [0, 0],
-			initialCursor: "move"
+			cursor: "move"
         },
         SETTINGS_KEY = 'kinetic-settings',
         ACTIVE_CLASS = 'kinetic-active';
@@ -338,8 +338,8 @@
             attachListeners($this, settings);
             $this.data(SETTINGS_KEY, settings);
 			
-			if(settings.initialCursor != null) {
-				$this.css("cursor", settings.initialCursor);
+			if(settings.cursor != null) {
+				$this.css("cursor", settings.cursor);
 			}
 			
 			// set up initial position
@@ -386,8 +386,8 @@
                 $this
                 .addClass(ACTIVE_CLASS);
 				
-				if(settings.initialCursor != null) {
-					$this.css("cursor", settings.initialCursor); 
+				if(settings.cursor != null) {
+					$this.css("cursor", settings.cursor); 
 				}
             }
         }

--- a/readme.mkd
+++ b/readme.mkd
@@ -62,7 +62,7 @@ The scrollbar plugin is still very much an alpha version.
 Options
 -------
 
-	initialCursor	{string}	default: "move"	This option offers the ability to disable the default "move" cursor, or over-ride it. Set to null to disable
+	cursor			{string}	default: "move"	This option offers the ability to disable the default "move" cursor, or over-ride it. Set to null to disable
 	initialOffset	{array}		default: [0,0]	This option allows you to specify the initial offset position of the item you are scrolling within the container
     slowdown        {number}    default: 0.9    This option affects the speed at which the scroll slows
     x               {string}    default: true   Toggles movement along the x axis


### PR DESCRIPTION
- Support for setting the initial offset position within the container
- Added an option to change the default cursor. Having the move cursor there added as inline CSS is not always preferable if you have other content that needs to be clicked inside the container and have relevent cursor changes.
