### PR TITLE
Fix detach method, broken since 1.6

### DIFF
--- a/jquery.kinetic.js
+++ b/jquery.kinetic.js
@@ -180,9 +180,9 @@
     var detachListeners = function($this, settings) {
         var element = $this[0];
         if ($.support.touch) {
-            element.removeEventListener('touchstart', settings.events.touchStart, false);
-            element.removeEventListener('touchend', settings.events.inputEnd, false);
-            element.removeEventListener('touchmove', settings.events.touchMove,false);
+            $this.unbind('touchstart', settings.events.touchStart)
+                .unbind('touchend', settings.events.inputEnd)
+                .unbind('touchmove', settings.events.touchMove);
         } else {
             $this
             .unbind('mousedown', settings.events.inputDown)


### PR DESCRIPTION
The "detach" method stopped working in version 1.6, because bound touch events weren't being unbound.
