### PR TITLE
Update CSS for triggerHardware option

### DIFF
--- a/jquery.kinetic.js
+++ b/jquery.kinetic.js
@@ -353,7 +353,11 @@
                 .css("cursor", settings.cursor);
 
             if (settings.triggerHardware) {
-                $this.css('-webkit-transform', 'translate3d(0,0,0)');
+                $this.css({
+                	'-webkit-transform': 'translate3d(0,0,0)',
+                	'-webkit-perspective': '1000',
+                	'-webkit-backface-visibility': 'hidden'
+                });
             }
         });
     };


### PR DESCRIPTION
As of iOS6, '-webkit-transform' alone is not necessarily enough to trigger hardware acceleration (see http://indiegamr.com/ios6-html-hardware-acceleration-changes-and-how-to-fix-them/)
