### PR TITLE
Optimize setMoveClasses(). Removing 7 extra calls.

### DIFF
--- a/jquery.kinetic.js
+++ b/jquery.kinetic.js
@@ -80,14 +80,7 @@
     };
 
     var setMoveClasses = function(settings, classes) {
-        this.removeClass(settings.movingClass.up)
-            .removeClass(settings.movingClass.down)
-            .removeClass(settings.movingClass.left)
-            .removeClass(settings.movingClass.right)
-            .removeClass(settings.deceleratingClass.up)
-            .removeClass(settings.deceleratingClass.down)
-            .removeClass(settings.deceleratingClass.left)
-            .removeClass(settings.deceleratingClass.right);
+        this.attr("class", "");
 
         if (settings.velocity > 0) {
             this.addClass(classes.right);


### PR DESCRIPTION
A quick performance test shows that it is much quicker to reset all of the classes with the `attr()` method.

http://jsperf.com/remove-class-versus-attribute-reset
