### PR TITLE
Stop inputEnd from stealing mouse up events

### DIFF
--- a/jquery.kinetic.js
+++ b/jquery.kinetic.js
@@ -327,9 +327,11 @@
                     }
                 },
                 inputEnd: function(e){
-                    end();
-                    elementFocused = null;
-                    if (e.preventDefault) {e.preventDefault();}
+                    if (useTarget(e.target, e)) {
+                        end();
+                        elementFocused = null;
+                        if (e.preventDefault) {e.preventDefault();}
+                    }
                 },
                 inputMove: function(e) {
                     if (mouseDown){


### PR DESCRIPTION
Currently the `inputEnd` functions prevent all mouseup event from propagating. IMHO it should only stop the event if the target belongs to it (i.e. `useTarget` return true).

An example: When binding jquery kinetic to an element containing a `<input type='range'>` the `inputEnd` event steals the event from the range input although the `useTarget` function returns false.

In the code example, the image is used to drag the entire body. But although the `filterTarget` should permit this, the input range is not working anymore... The mouseup event is never fired. 

``` html
<!DOCTYPE HTML>
<html>
    <head>
        <script src="lib/jquery-1.5.1.min.js" type="text/javascript" charset="utf-8"></script>
        <script src="jquery.kinetic.js" type="text/javascript" charset="utf-8"></script>
        <style type="text/css">
            body {
                font-family: arial, sans-serif;
            }
        </style>
    </head>
    <body>
        <h3>Use the image to drag the body, but watch out when using the range input.</h3>
        <input type="range" name="points" min="1" max="10">
        <div id="dragger">
            <img src="lib/wembley.jpg">
        </div>
        <script type="text/javascript" charset="utf-8">
            $('body').kinetic({
                filterTarget: function(target, ev){
                    return $(target).parents('#dragger').length > 0;
                }
            });
        </script>
    </body>
</html>
```

The patch should fix this. Please review.
