### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ NB. [@dzek69](https://github.com/dzek69) has created a version of this plugin wi
 ### npm
 
 	$ npm install jquery.kinetic
+	
+### CDN
+
+	<script src="https://cdn.jsdelivr.net/npm/jquery.kinetic/jquery.kinetic.js"></script>
 
 ### Script tag
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/jquery.kinetic) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.